### PR TITLE
ssync: fixed interval splitter aligment to batch size

### DIFF
--- a/sparse/file.go
+++ b/sparse/file.go
@@ -37,8 +37,13 @@ func IntervalSplitter(spltterStream <-chan FileInterval, fileStream chan<- FileI
 				if offset+size > r.End {
 					size = r.End - offset
 				}
-				fileStream <- FileInterval{SparseData, Interval{offset, offset + size}}
-				offset += size
+				interval := Interval{offset, offset + size}
+				if size == batch && interval.End%batch != 0 {
+					interval.End = interval.End / batch * batch
+				}
+				log.Debug("Interval Splitter data:", interval)
+				fileStream <- FileInterval{SparseData, interval}
+				offset += interval.Len()
 			}
 		}
 	}


### PR DESCRIPTION
Without the alignment the client produced extra block batch diffs that otherwise would match.
Impact: 
the correctness was not impacted but there was extra network traffic in high density files with few non-matching holes
