### PR TITLE
Sfold read/write 32 blocks instead of one block

### DIFF
--- a/sparse/client.go
+++ b/sparse/client.go
@@ -17,7 +17,8 @@ type TCPEndPoint struct {
 	Port int16
 }
 
-const connectionRetries = 5
+// we should disable this when we are confident
+const enableFinalMD5 = true
 
 // SyncFile synchronizes local file to remote host
 func SyncFile(localPath string, addr TCPEndPoint, remotePath string, timeout int) ([]byte, error) {
@@ -77,7 +78,13 @@ func syncFile(localPath string, addr TCPEndPoint, remotePath string, timeout int
 	if err != nil {
 		log.Error("syncFileContent failed: ", err)
 	}
-	return nil, err
+
+	if enableFinalMD5 && !AreFilesEqual(localPath, remotePath) {
+		log.Error("After syncFileContent, local and remote files are different")
+		return nil, fmt.Errorf("file: %s differs from file: %s", localPath, remotePath)
+	}
+
+	return nil, nil
 }
 
 func connect(host, port string, timeout int) net.Conn {

--- a/sparse/file.go
+++ b/sparse/file.go
@@ -1,6 +1,8 @@
 package sparse
 
 import (
+	"bytes"
+	"crypto/md5"
 	"crypto/sha512"
 	"fmt"
 	"io"
@@ -201,4 +203,36 @@ func GetFiemapExtents(file FileIoProcessor) ([]Extent, error) {
 	}
 
 	return exts, nil
+}
+
+func AreFilesEqual(aPath string, bPath string) bool {
+	aHash, err := hashFileMD5(aPath)
+	if err != nil {
+		log.Errorf("Failed hashFileMD5 with file: %s", aPath)
+		return true
+	}
+	bHash, err := hashFileMD5(bPath)
+	if err != nil {
+		log.Errorf("Failed hashFileMD5 with file: %s", bPath)
+		return true
+	}
+
+	return bytes.Equal(aHash, bHash)
+}
+
+func hashFileMD5(filePath string) ([]byte, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+
+	//Copy the file in the hash interface and check for any error
+	if _, err := io.Copy(hash, file); err != nil {
+		return nil, err
+	}
+
+	return hash.Sum(nil), nil
 }


### PR DESCRIPTION
Let's add md5 digest comparison when ssync is done, to rule out ssync corrupting data that we saw. So we can move on to look into other parts of longhorn. Of course we hope we can repro that issue.

@yasker @sheng-liang 
