### PR TITLE
optimize ssync and fix sfold infinite loop folding issue

### DIFF
--- a/sparse/client.go
+++ b/sparse/client.go
@@ -257,9 +257,16 @@ func (client *syncClient) syncDataInterval(file FileIoProcessor, dataInterval In
 		}
 
 		serverNeedData := true
+
+		// read data either for checksum, sending, or both
+		dataBuffer, err := ReadDataInterval(file, batchInterval)
+		if err != nil {
+			log.Errorf("ReadDataInterval for batchInterval: %s failed, err: %s", batchInterval, err)
+			return err
+		}
 		if len(serverCheckSum) != 0 {
 			// calculate local checksum for the data batch interval
-			localCheckSum, err := HashDataInterval(file, batchInterval)
+			localCheckSum, err := HashDataInterval(dataBuffer)
 			if err != nil {
 				log.Errorf("HashDataInterval locally: %s failed, err: %s", batchInterval, err)
 				return err
@@ -269,12 +276,6 @@ func (client *syncClient) syncDataInterval(file FileIoProcessor, dataInterval In
 			serverNeedData = !bytes.Equal(serverCheckSum, localCheckSum)
 		}
 		if serverNeedData {
-			dataBuffer, err := ReadDataInterval(file, batchInterval)
-			if err != nil {
-				log.Errorf("ReadDataInterval for batchInterval: %s failed, err: %s", batchInterval, err)
-				return err
-			}
-
 			// send data buffer
 			log.Debugf("sending dataBuffer size: %d", len(dataBuffer))
 			err = client.writeData(batchInterval, dataBuffer)

--- a/sparse/file.go
+++ b/sparse/file.go
@@ -163,11 +163,15 @@ func WriteDataInterval(file FileIoProcessor, dataInterval Interval, data []byte)
 	return nil
 }
 
-func HashDataInterval(file FileIoProcessor, dataInterval Interval) ([]byte, error) {
+func HashFileInterval(file FileIoProcessor, dataInterval Interval) ([]byte, error) {
 	data, err := ReadDataInterval(file, dataInterval)
 	if err != nil {
 		return nil, err
 	}
+	return HashDataInterval(data)
+}
+
+func HashDataInterval(data []byte) ([]byte, error) {
 	sum := sha512.Sum512(data)
 	return sum[:], nil
 }

--- a/sparse/rest/handlers.go
+++ b/sparse/rest/handlers.go
@@ -135,7 +135,7 @@ func (server *SyncServer) doGetChecksum(writer http.ResponseWriter, request *htt
 	if len(exts) == 1 && int64(exts[0].Logical) <= remoteDataInterval.Begin &&
 		int64(exts[0].Logical+exts[0].Length) >= remoteDataInterval.End {
 
-		checksum, err = sparse.HashDataInterval(server.fileIo, remoteDataInterval)
+		checksum, err = sparse.HashFileInterval(server.fileIo, remoteDataInterval)
 		if err != nil {
 			return fmt.Errorf("HashDataInterval locally: %s failed, err: %s", remoteDataInterval, err)
 		}

--- a/sparse/sfold.go
+++ b/sparse/sfold.go
@@ -54,44 +54,41 @@ func coalesce(parentFileIo FileIoProcessor, childFileIo FileIoProcessor) error {
 	if err != nil {
 		panic("can't get FS block size, error: " + err.Error())
 	}
-	var data, hole int64
-	for {
-		data, _ = childFileIo.Seek(hole, seekData)
-		if data < hole {
-			break
-		}
-		hole, err = childFileIo.Seek(data, seekHole)
-		if err != nil {
-			log.Error("Failed to syscall.Seek SEEK_HOLE")
-			return err
-		}
+	exts, err := GetFiemapExtents(childFileIo)
+	if err != nil {
+		log.Errorf("Failed to GetFiemapExtents of childFile filename: %v", childFileIo.Name())
+		return err
+	}
+	for _, e := range exts {
+		dataBegin := int64(e.Logical)
+		dataEnd := int64(e.Logical + e.Length)
 
 		// now we have a data start offset and length(hole - data)
 		// let's read from child and write to parent file. We read/write up to
 		// 32 blocks in a batch
-		_, err = parentFileIo.Seek(data, os.SEEK_SET)
+		_, err = parentFileIo.Seek(dataBegin, os.SEEK_SET)
 		if err != nil {
-			log.Error("Failed to os.Seek os.SEEK_SET")
+			log.Errorf("Failed to os.Seek os.SEEK_SET parentFile filename: %v, at: %v", parentFileIo.Name(), dataBegin)
 			return err
 		}
 
 		batch := batchBlockCount * blockSize
 		buffer := AllocateAligned(batch)
-		for offset := data; offset < hole; {
+		for offset := dataBegin; offset < dataEnd; {
 			size := batch
-			if offset+int64(size) > hole {
-				size = int(hole - offset)
+			if offset+int64(size) > dataEnd {
+				size = int(dataEnd - offset)
 			}
 			// read a batch from child
 			n, err := childFileIo.ReadAt(buffer[:size], offset)
 			if err != nil {
-				log.Error("Failed to read from childFile")
+				log.Errorf("Failed to read childFile filename: %v, size: %v, at: %v", childFileIo.Name(), size, offset)
 				return err
 			}
 			// write a batch to parent
 			n, err = parentFileIo.WriteAt(buffer[:size], offset)
 			if err != nil {
-				log.Error("Failed to write to parentFile")
+				log.Errorf("Failed to write to parentFile filename: %v, size: %v, at: %v", parentFileIo.Name(), size, offset)
 				return err
 			}
 			offset += int64(n)

--- a/sparse/test/sfold_test.go
+++ b/sparse/test/sfold_test.go
@@ -87,6 +87,21 @@ func TestFoldFile2(t *testing.T) {
 	testFoldFile(t, layoutFrom, layoutTo)
 }
 
+func TestFoldFile3(t *testing.T) {
+	// H H H  => D H H
+	layoutFrom := []FileInterval{
+		{SparseHole, Interval{0, 1 * Blocks}},
+		{SparseHole, Interval{1 * Blocks, 2 * Blocks}},
+		{SparseHole, Interval{2 * Blocks, 3 * Blocks}},
+	}
+	layoutTo := []FileInterval{
+		{SparseData, Interval{0, 1 * Blocks}},
+		{SparseHole, Interval{1 * Blocks, 2 * Blocks}},
+		{SparseHole, Interval{2 * Blocks, 3 * Blocks}},
+	}
+	testFoldFile(t, layoutFrom, layoutTo)
+}
+
 func foldLayout(from, to []FileInterval) []FileInterval {
 	if len(from) != len(to) {
 		log.Fatal("foldLayout: non equal length not implemented")

--- a/sparse/test/testutil_test.go
+++ b/sparse/test/testutil_test.go
@@ -125,7 +125,10 @@ func checkTestSparseFile(name string, layout []FileInterval) error {
 			if len(layoutActual) != 1 {
 				return errors.New(fmt.Sprint("hole check failure at", interval))
 			}
-			if layoutActual[0] != interval {
+			// actual hole must cover interval span
+			if layoutActual[0].Kind != interval.Kind ||
+				layoutActual[0].Begin > interval.Begin ||
+				layoutActual[0].End < interval.End {
 				return errors.New(fmt.Sprint("hole equality check failure at", interval))
 			}
 		}


### PR DESCRIPTION
- optimize ssync client reading file just once either for checksum, send data or both
- fix sfold infinite loop folding from pure hole child
- add a test case for sfold_test when folding pure hole child into parent

@yasker @sheng-liang 
