### PR TITLE
add sfold error logging and remove checking logic in GetFiemapRegionExts

### DIFF
--- a/cli/sfold/main.go
+++ b/cli/sfold/main.go
@@ -46,6 +46,7 @@ Examples:
 
 	err := sparse.FoldFile(srcPath, dstPath)
 	if err != nil {
+		log.Errorf("failed to fold file: %s to: %s, err: %v", srcPath, dstPath, err)
 		os.Exit(1)
 	}
 }

--- a/sparse/file.go
+++ b/sparse/file.go
@@ -220,10 +220,5 @@ func GetFiemapRegionExts(file FileIoProcessor, interval Interval) ([]Extent, err
 		lastExtStart = ext.Logical
 	}
 
-	// last ext should have the FIEMAP_EXTENT_LAST set, otherwise we don't get all exts
-	if exts[len(exts)-1].Flags&FIEMAP_EXTENT_LAST == 0 {
-		return exts, fmt.Errorf("The exts returned by fiemap are not complete")
-	}
-
 	return exts, nil
 }

--- a/sparse/sfold.go
+++ b/sparse/sfold.go
@@ -56,7 +56,7 @@ func coalesce(parentFileIo FileIoProcessor, childFileIo FileIoProcessor) error {
 	}
 	exts, err := GetFiemapExtents(childFileIo)
 	if err != nil {
-		log.Errorf("Failed to GetFiemapExtents of childFile filename: %v", childFileIo.Name())
+		log.Errorf("Failed to GetFiemapExtents of childFile filename: %s, err: %v", childFileIo.Name(), err)
 		return err
 	}
 	for _, e := range exts {


### PR DESCRIPTION
add sfold error logging for future and remove checking logic for getting fiemap exts in a region for issue #218

@yasker 
