### PR TITLE
Report progress of sfold operation

### DIFF
--- a/sparse/sfold.go
+++ b/sparse/sfold.go
@@ -1,6 +1,7 @@
 package sparse
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 
@@ -8,11 +9,16 @@ import (
 )
 
 const (
-	batchBlockCount = 32
+	batchBlockCount  = 32
+	progressComplete = 100
 )
 
+type FoldFileOperations interface {
+	UpdateFoldFileProgress(progress int, done bool, err error)
+}
+
 // FoldFile folds child snapshot data into its parent
-func FoldFile(childFileName, parentFileName string) error {
+func FoldFile(childFileName, parentFileName string, ops FoldFileOperations) error {
 
 	childFInfo, err := os.Stat(childFileName)
 	if err != nil {
@@ -33,6 +39,23 @@ func FoldFile(childFileName, parentFileName string) error {
 		panic("file sizes are not equal")
 	}
 
+	go coalesce(parentFileName, childFileName, childFInfo.Size(), ops)
+
+	return nil
+}
+
+func coalesce(parentFileName, childFileName string, fileSize int64, ops FoldFileOperations) (err error) {
+	var progress int
+
+	defer func() {
+		if err != nil {
+			log.Errorf(err.Error())
+			ops.UpdateFoldFileProgress(progress, true, err)
+		} else {
+			ops.UpdateFoldFileProgress(progressComplete, true, nil)
+		}
+	}()
+
 	// open child and parent files
 	childFileIo, err := NewDirectFileIoProcessor(childFileName, os.O_RDONLY, 0)
 	if err != nil {
@@ -46,19 +69,15 @@ func FoldFile(childFileName, parentFileName string) error {
 	}
 	defer parentFileIo.Close()
 
-	return coalesce(parentFileIo, childFileIo)
-}
-
-func coalesce(parentFileIo FileIoProcessor, childFileIo FileIoProcessor) error {
 	blockSize, err := getFileSystemBlockSize(childFileIo)
 	if err != nil {
 		panic("can't get FS block size, error: " + err.Error())
 	}
 	exts, err := GetFiemapExtents(childFileIo)
 	if err != nil {
-		log.Errorf("Failed to GetFiemapExtents of childFile filename: %s, err: %v", childFileIo.Name(), err)
-		return err
+		return fmt.Errorf("failed to GetFiemapExtents of childFile filename: %s, err: %v", childFileIo.Name(), err)
 	}
+
 	for _, e := range exts {
 		dataBegin := int64(e.Logical)
 		dataEnd := int64(e.Logical + e.Length)
@@ -68,30 +87,31 @@ func coalesce(parentFileIo FileIoProcessor, childFileIo FileIoProcessor) error {
 		// 32 blocks in a batch
 		_, err = parentFileIo.Seek(dataBegin, os.SEEK_SET)
 		if err != nil {
-			log.Errorf("Failed to os.Seek os.SEEK_SET parentFile filename: %v, at: %v", parentFileIo.Name(), dataBegin)
-			return err
+			return fmt.Errorf("Failed to os.Seek os.SEEK_SET parentFile filename: %v, at: %v", parentFileIo.Name(), dataBegin)
 		}
 
 		batch := batchBlockCount * blockSize
 		buffer := AllocateAligned(batch)
 		for offset := dataBegin; offset < dataEnd; {
+			var n int
+
 			size := batch
 			if offset+int64(size) > dataEnd {
 				size = int(dataEnd - offset)
 			}
 			// read a batch from child
-			n, err := childFileIo.ReadAt(buffer[:size], offset)
+			n, err = childFileIo.ReadAt(buffer[:size], offset)
 			if err != nil {
-				log.Errorf("Failed to read childFile filename: %v, size: %v, at: %v", childFileIo.Name(), size, offset)
-				return err
+				return fmt.Errorf("Failed to read childFile filename: %v, size: %v, at: %v", childFileIo.Name(), size, offset)
 			}
 			// write a batch to parent
 			n, err = parentFileIo.WriteAt(buffer[:size], offset)
 			if err != nil {
-				log.Errorf("Failed to write to parentFile filename: %v, size: %v, at: %v", parentFileIo.Name(), size, offset)
-				return err
+				return fmt.Errorf("Failed to write to parentFile filename: %v, size: %v, at: %v", parentFileIo.Name(), size, offset)
 			}
 			offset += int64(n)
+			progress = int(float64(offset) / float64(fileSize) * 100)
+			ops.UpdateFoldFileProgress(progress, false, nil)
 		}
 	}
 

--- a/sparse/sfold.go
+++ b/sparse/sfold.go
@@ -19,24 +19,23 @@ type FoldFileOperations interface {
 
 // FoldFile folds child snapshot data into its parent
 func FoldFile(childFileName, parentFileName string, ops FoldFileOperations) error {
-
 	childFInfo, err := os.Stat(childFileName)
 	if err != nil {
-		panic("os.Stat(childFileName) failed, error: " + err.Error())
+		return fmt.Errorf("os.Stat(childFileName) failed, error: %v", err)
 	}
 	parentFInfo, err := os.Stat(parentFileName)
 	if err != nil {
-		panic("os.Stat(parentFileName) failed, error: " + err.Error())
+		return fmt.Errorf("os.Stat(parentFileName) failed, error: %v", err)
 	}
 
 	// ensure no directory
 	if childFInfo.IsDir() || parentFInfo.IsDir() {
-		panic("at least one file is directory, not a normal file")
+		return fmt.Errorf("at least one file is directory, not a normal file")
 	}
 
 	// ensure file sizes are equal
 	if childFInfo.Size() != parentFInfo.Size() {
-		panic("file sizes are not equal")
+		return fmt.Errorf("file sizes are not equal")
 	}
 
 	go coalesce(parentFileName, childFileName, childFInfo.Size(), ops)
@@ -59,19 +58,19 @@ func coalesce(parentFileName, childFileName string, fileSize int64, ops FoldFile
 	// open child and parent files
 	childFileIo, err := NewDirectFileIoProcessor(childFileName, os.O_RDONLY, 0)
 	if err != nil {
-		panic("Failed to open childFile, error: " + err.Error())
+		return fmt.Errorf("failed to open childFile, error: %v", err)
 	}
 	defer childFileIo.Close()
 
 	parentFileIo, err := NewDirectFileIoProcessor(parentFileName, os.O_WRONLY, 0)
 	if err != nil {
-		panic("Failed to open parentFile, error: " + err.Error())
+		return fmt.Errorf("failed to open parentFile, error: %v", err)
 	}
 	defer parentFileIo.Close()
 
 	blockSize, err := getFileSystemBlockSize(childFileIo)
 	if err != nil {
-		panic("can't get FS block size, error: " + err.Error())
+		return fmt.Errorf("can't get FS block size, error: %v", err)
 	}
 	exts, err := GetFiemapExtents(childFileIo)
 	if err != nil {


### PR DESCRIPTION
This PR modifies the logic of the `sfold` operation to allow for the `Progress` of the operation to be reported.

As part of the call to `FoldFile`, the user must provide a `struct` that implements `FoldFileOperations`, an interface declaring a `method` named `UpdateFoldFileProgress`, that will be used to report the status of the `FoldFile` operation via `callback`.

As part of the changes to allow for `sfold` to report its `Progress`, the `coalesce` function that `FoldFile` uses has been converted to a `goroutine`, meaning that `FoldFile` no longer blocks and will immediately return once the `sfold` operation has started. It is up to the user to implement `FoldFileOperations` and respond to the `Progress` changes of the operation accordingly.

The default implementations used by `sfold` in the `CLI` and in the tests have also been modified to implement `FoldFileOperations`, waiting for a `Done` status and sending any `error` that might've occurred during the operation.