### PR TITLE
Revert "Report progress of sfold operation"

### DIFF
--- a/cli/sfold/main.go
+++ b/cli/sfold/main.go
@@ -10,16 +10,6 @@ import (
 	"github.com/longhorn/sparse-tools/sparse"
 )
 
-type FoldFileCLI struct {
-	doneChan chan error
-}
-
-func (f *FoldFileCLI) UpdateFoldFileProgress(progress int, done bool, err error) {
-	if done {
-		f.doneChan <- err
-	}
-}
-
 func Main() {
 	defaultNonVerboseLogLevel := log.DebugLevel // set if -verbose is false
 	// Command line parsing
@@ -55,15 +45,8 @@ Examples:
 		log.SetLevel(defaultNonVerboseLogLevel)
 	}
 
-	ops := &FoldFileCLI{
-		doneChan: make(chan error),
-	}
-	err := sparse.FoldFile(srcPath, dstPath, ops)
+	err := sparse.FoldFile(srcPath, dstPath)
 	if err != nil {
-		log.Errorf("error starting to fold file: %s to: %s, err:%v", srcPath, dstPath, err)
-		os.Exit(1)
-	}
-	if err := <-ops.doneChan; err != nil {
 		log.Errorf("failed to fold file: %s to: %s, err: %v", srcPath, dstPath, err)
 		os.Exit(1)
 	}

--- a/sparse/sfold.go
+++ b/sparse/sfold.go
@@ -19,23 +19,24 @@ type FoldFileOperations interface {
 
 // FoldFile folds child snapshot data into its parent
 func FoldFile(childFileName, parentFileName string, ops FoldFileOperations) error {
+
 	childFInfo, err := os.Stat(childFileName)
 	if err != nil {
-		return fmt.Errorf("os.Stat(childFileName) failed, error: %v", err)
+		panic("os.Stat(childFileName) failed, error: " + err.Error())
 	}
 	parentFInfo, err := os.Stat(parentFileName)
 	if err != nil {
-		return fmt.Errorf("os.Stat(parentFileName) failed, error: %v", err)
+		panic("os.Stat(parentFileName) failed, error: " + err.Error())
 	}
 
 	// ensure no directory
 	if childFInfo.IsDir() || parentFInfo.IsDir() {
-		return fmt.Errorf("at least one file is directory, not a normal file")
+		panic("at least one file is directory, not a normal file")
 	}
 
 	// ensure file sizes are equal
 	if childFInfo.Size() != parentFInfo.Size() {
-		return fmt.Errorf("file sizes are not equal")
+		panic("file sizes are not equal")
 	}
 
 	go coalesce(parentFileName, childFileName, childFInfo.Size(), ops)
@@ -58,19 +59,19 @@ func coalesce(parentFileName, childFileName string, fileSize int64, ops FoldFile
 	// open child and parent files
 	childFileIo, err := NewDirectFileIoProcessor(childFileName, os.O_RDONLY, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open childFile, error: %v", err)
+		panic("Failed to open childFile, error: " + err.Error())
 	}
 	defer childFileIo.Close()
 
 	parentFileIo, err := NewDirectFileIoProcessor(parentFileName, os.O_WRONLY, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open parentFile, error: %v", err)
+		panic("Failed to open parentFile, error: " + err.Error())
 	}
 	defer parentFileIo.Close()
 
 	blockSize, err := getFileSystemBlockSize(childFileIo)
 	if err != nil {
-		return fmt.Errorf("can't get FS block size, error: %v", err)
+		panic("can't get FS block size, error: " + err.Error())
 	}
 	exts, err := GetFiemapExtents(childFileIo)
 	if err != nil {

--- a/sparse/test/sfold_test.go
+++ b/sparse/test/sfold_test.go
@@ -9,22 +9,6 @@ import (
 	. "github.com/longhorn/sparse-tools/sparse"
 )
 
-type FoldFileTest struct {
-	doneChan    chan error
-	progress    int
-	progressErr bool
-}
-
-func (f *FoldFileTest) UpdateFoldFileProgress(progress int, done bool, err error) {
-	if progress < f.progress {
-		f.progressErr = true
-	}
-	f.progress = progress
-	if done {
-		f.doneChan <- err
-	}
-}
-
 func TestFoldFile1(t *testing.T) {
 	// D H D => D D H
 	layoutFrom := []FileInterval{
@@ -174,24 +158,11 @@ func testFoldFile(t *testing.T, layoutFrom, layoutTo []FileInterval) (hashLocal 
 	foldLayout(layoutFrom, layoutTo, fromPath, toPath, expectedPath)
 
 	// Fold
-	ops := &FoldFileTest{
-		doneChan: make(chan error),
-	}
-	err := FoldFile(fromPath, toPath, ops)
+	err := FoldFile(fromPath, toPath)
+
+	// Verify
 	if err != nil {
-		t.Fatal("Start fold error:", err)
-	}
-
-	if err := <-ops.doneChan; err != nil {
 		t.Fatal("Fold error:", err)
-	}
-
-	if ops.progress != 100 {
-		t.Fatal("Completed fold does not have progress of 100")
-	}
-
-	if ops.progressErr {
-		t.Fatal("Progress went backwards during fold")
 	}
 
 	err = checkSparseFiles(toPath, expectedPath)


### PR DESCRIPTION
Reverts longhorn/sparse-tools#58

Revert the change because we realized it's not necessary to make the call asynchornized. 