### PR TITLE
Track progress of FoldFile

### DIFF
--- a/cli/sfold/main.go
+++ b/cli/sfold/main.go
@@ -10,6 +10,10 @@ import (
 	"github.com/longhorn/sparse-tools/sparse"
 )
 
+type FoldFileStub struct{}
+
+func (f *FoldFileStub) UpdateFoldFileProgress(progress int, done bool, err error) {}
+
 func Main() {
 	defaultNonVerboseLogLevel := log.DebugLevel // set if -verbose is false
 	// Command line parsing
@@ -45,7 +49,8 @@ Examples:
 		log.SetLevel(defaultNonVerboseLogLevel)
 	}
 
-	err := sparse.FoldFile(srcPath, dstPath)
+	ops := &FoldFileStub{}
+	err := sparse.FoldFile(srcPath, dstPath, ops)
 	if err != nil {
 		log.Errorf("failed to fold file: %s to: %s, err: %v", srcPath, dstPath, err)
 		os.Exit(1)

--- a/sparse/sfold.go
+++ b/sparse/sfold.go
@@ -1,6 +1,7 @@
 package sparse
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 
@@ -8,11 +9,16 @@ import (
 )
 
 const (
-	batchBlockCount = 32
+	batchBlockCount  = 32
+	progressComplete = 100
 )
 
+type FoldFileOperations interface {
+	UpdateFoldFileProgress(progress int, done bool, err error)
+}
+
 // FoldFile folds child snapshot data into its parent
-func FoldFile(childFileName, parentFileName string) error {
+func FoldFile(childFileName, parentFileName string, ops FoldFileOperations) error {
 
 	childFInfo, err := os.Stat(childFileName)
 	if err != nil {
@@ -46,19 +52,30 @@ func FoldFile(childFileName, parentFileName string) error {
 	}
 	defer parentFileIo.Close()
 
-	return coalesce(parentFileIo, childFileIo)
+	return coalesce(parentFileIo, childFileIo, childFInfo.Size(), ops)
 }
 
-func coalesce(parentFileIo FileIoProcessor, childFileIo FileIoProcessor) error {
+func coalesce(parentFileIo, childFileIo FileIoProcessor, fileSize int64, ops FoldFileOperations) (err error) {
+	var progress int
+
+	defer func() {
+		if err != nil {
+			log.Errorf(err.Error())
+			ops.UpdateFoldFileProgress(progress, true, err)
+		} else {
+			ops.UpdateFoldFileProgress(progressComplete, true, nil)
+		}
+	}()
+
 	blockSize, err := getFileSystemBlockSize(childFileIo)
 	if err != nil {
 		panic("can't get FS block size, error: " + err.Error())
 	}
 	exts, err := GetFiemapExtents(childFileIo)
 	if err != nil {
-		log.Errorf("Failed to GetFiemapExtents of childFile filename: %s, err: %v", childFileIo.Name(), err)
-		return err
+		return fmt.Errorf("failed to GetFiemapExtents of childFile filename: %s, err: %v", childFileIo.Name(), err)
 	}
+
 	for _, e := range exts {
 		dataBegin := int64(e.Logical)
 		dataEnd := int64(e.Logical + e.Length)
@@ -68,30 +85,31 @@ func coalesce(parentFileIo FileIoProcessor, childFileIo FileIoProcessor) error {
 		// 32 blocks in a batch
 		_, err = parentFileIo.Seek(dataBegin, os.SEEK_SET)
 		if err != nil {
-			log.Errorf("Failed to os.Seek os.SEEK_SET parentFile filename: %v, at: %v", parentFileIo.Name(), dataBegin)
-			return err
+			return fmt.Errorf("Failed to os.Seek os.SEEK_SET parentFile filename: %v, at: %v", parentFileIo.Name(), dataBegin)
 		}
 
 		batch := batchBlockCount * blockSize
 		buffer := AllocateAligned(batch)
 		for offset := dataBegin; offset < dataEnd; {
+			var n int
+
 			size := batch
 			if offset+int64(size) > dataEnd {
 				size = int(dataEnd - offset)
 			}
 			// read a batch from child
-			n, err := childFileIo.ReadAt(buffer[:size], offset)
+			n, err = childFileIo.ReadAt(buffer[:size], offset)
 			if err != nil {
-				log.Errorf("Failed to read childFile filename: %v, size: %v, at: %v", childFileIo.Name(), size, offset)
-				return err
+				return fmt.Errorf("Failed to read childFile filename: %v, size: %v, at: %v", childFileIo.Name(), size, offset)
 			}
 			// write a batch to parent
 			n, err = parentFileIo.WriteAt(buffer[:size], offset)
 			if err != nil {
-				log.Errorf("Failed to write to parentFile filename: %v, size: %v, at: %v", parentFileIo.Name(), size, offset)
-				return err
+				return fmt.Errorf("Failed to write to parentFile filename: %v, size: %v, at: %v", parentFileIo.Name(), size, offset)
 			}
 			offset += int64(n)
+			progress = int(float64(offset) / float64(fileSize) * 100)
+			ops.UpdateFoldFileProgress(progress, false, nil)
 		}
 	}
 

--- a/sparse/sfold.go
+++ b/sparse/sfold.go
@@ -19,36 +19,35 @@ type FoldFileOperations interface {
 
 // FoldFile folds child snapshot data into its parent
 func FoldFile(childFileName, parentFileName string, ops FoldFileOperations) error {
-
 	childFInfo, err := os.Stat(childFileName)
 	if err != nil {
-		panic("os.Stat(childFileName) failed, error: " + err.Error())
+		return fmt.Errorf("os.Stat(childFileName) failed, error: %v", err)
 	}
 	parentFInfo, err := os.Stat(parentFileName)
 	if err != nil {
-		panic("os.Stat(parentFileName) failed, error: " + err.Error())
+		return fmt.Errorf("os.Stat(parentFileName) failed, error: %v", err)
 	}
 
 	// ensure no directory
 	if childFInfo.IsDir() || parentFInfo.IsDir() {
-		panic("at least one file is directory, not a normal file")
+		return fmt.Errorf("at least one file is directory, not a normal file")
 	}
 
 	// ensure file sizes are equal
 	if childFInfo.Size() != parentFInfo.Size() {
-		panic("file sizes are not equal")
+		return fmt.Errorf("file sizes are not equal")
 	}
 
 	// open child and parent files
 	childFileIo, err := NewDirectFileIoProcessor(childFileName, os.O_RDONLY, 0)
 	if err != nil {
-		panic("Failed to open childFile, error: " + err.Error())
+		return fmt.Errorf("failed to open childFile, error: %v", err)
 	}
 	defer childFileIo.Close()
 
 	parentFileIo, err := NewDirectFileIoProcessor(parentFileName, os.O_WRONLY, 0)
 	if err != nil {
-		panic("Failed to open parentFile, error: " + err.Error())
+		return fmt.Errorf("failed to open parentFile, error: %v", err)
 	}
 	defer parentFileIo.Close()
 
@@ -69,7 +68,7 @@ func coalesce(parentFileIo, childFileIo FileIoProcessor, fileSize int64, ops Fol
 
 	blockSize, err := getFileSystemBlockSize(childFileIo)
 	if err != nil {
-		panic("can't get FS block size, error: " + err.Error())
+		return fmt.Errorf("can't get FS block size, error: %v", err)
 	}
 	exts, err := GetFiemapExtents(childFileIo)
 	if err != nil {

--- a/sparse/test/sfold_test.go
+++ b/sparse/test/sfold_test.go
@@ -9,6 +9,18 @@ import (
 	. "github.com/longhorn/sparse-tools/sparse"
 )
 
+type FoldFileTest struct {
+	progress    int
+	progressErr bool
+}
+
+func (f *FoldFileTest) UpdateFoldFileProgress(progress int, done bool, err error) {
+	if progress < f.progress {
+		f.progressErr = true
+	}
+	f.progress = progress
+}
+
 func TestFoldFile1(t *testing.T) {
 	// D H D => D D H
 	layoutFrom := []FileInterval{
@@ -158,11 +170,18 @@ func testFoldFile(t *testing.T, layoutFrom, layoutTo []FileInterval) (hashLocal 
 	foldLayout(layoutFrom, layoutTo, fromPath, toPath, expectedPath)
 
 	// Fold
-	err := FoldFile(fromPath, toPath)
-
-	// Verify
+	ops := &FoldFileTest{}
+	err := FoldFile(fromPath, toPath, ops)
 	if err != nil {
 		t.Fatal("Fold error:", err)
+	}
+
+	if ops.progress != 100 {
+		t.Fatal("Completed fold does not have progress of 100")
+	}
+
+	if ops.progressErr {
+		t.Fatal("Progress went backwards during fold")
 	}
 
 	err = checkSparseFiles(toPath, expectedPath)


### PR DESCRIPTION
This PR reimplements the `Progress` tracking of the `sfold` operation that was introduced in #58, but keeps the synchronous nature of the `FoldFile` command.

Note that this means that the call to `FoldFile` will be blocking until the operation completes, and `UpdateFoldFileProgress` should be implemented in a way such that it doesn't indefinitely block the `FoldFile` operation when it is called.