### PR TITLE
add endpoint for syncing metafile

### DIFF
--- a/sparse/rest/router.go
+++ b/sparse/rest/router.go
@@ -14,6 +14,6 @@ func NewRouter(server *SyncServer) *mux.Router {
 	router.HandleFunc("/v1-ssync/close", server.close).Methods("POST")
 	router.HandleFunc("/v1-ssync/sendHole", server.sendHole).Methods("POST")
 	router.HandleFunc("/v1-ssync/writeData", server.writeData).Methods("POST")
-
+	router.HandleFunc("/v1-ssync/writeMetaData", server.writeMetaFile).Methods("POST")
 	return router
 }


### PR DESCRIPTION
This commit adds an endpoint `writeMetaFile` to sync the contents
of metafile by writing the data into temp file and then renaming it
to  make contents of file consistent across crashes.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>