### PR TITLE
add command line argument directio (#1943)

### DIFF
--- a/cli/ssync/main.go
+++ b/cli/ssync/main.go
@@ -25,6 +25,7 @@ func Main() {
 	port := flag.String("port", "5000", "optional daemon port")
 	timeout := flag.Int("timeout", 120, "optional daemon/client timeout (seconds)")
 	host := flag.String("host", "", "remote host of <DstFile> (requires running daemon)")
+	directIO := flag.Bool("directIO", true, "optional client sync file using directIO")
 
 	flag.Parse()
 
@@ -53,7 +54,7 @@ func Main() {
 		srcPath := args[0]
 		log.Infof("Syncing %s to %s:%s...\n", srcPath, *host, *port)
 
-		err := sparse.SyncFile(srcPath, *host+":"+*port, *timeout)
+		err := sparse.SyncFile(srcPath, *host+":"+*port, *timeout, *directIO)
 		if err != nil {
 			log.Fatalf("Ssync client failed, error: %s", err)
 		}

--- a/sparse/client.go
+++ b/sparse/client.go
@@ -30,14 +30,13 @@ type syncClient struct {
 const connectionRetries = 5
 
 // SyncFile synchronizes local file to remote host
-func SyncFile(localPath string, remote string, timeout int) error {
+func SyncFile(localPath string, remote string, timeout int, directIO bool) error {
 	fileInfo, err := os.Stat(localPath)
 	if err != nil {
 		log.Errorf("Failed to get size of source file: %s, err: %s", localPath, err)
 		return err
 	}
 	fileSize := fileInfo.Size()
-	directIO := (fileSize%Blocks == 0)
 	log.Infof("source file size: %d, setting up directIo: %v", fileSize, directIO)
 
 	var fileIo FileIoProcessor

--- a/sparse/test/client_test.go
+++ b/sparse/test/client_test.go
@@ -22,7 +22,7 @@ func TestSyncSmallFile1(t *testing.T) {
 
 	data := []byte("json-fault")
 	createTestSmallFile(localPath, len(data), data)
-	testSyncAnyFile(t, localPath, remotePath)
+	testSyncAnyFile(t, localPath, remotePath, false /* directIO */)
 }
 
 func TestSyncSmallFile2(t *testing.T) {
@@ -36,7 +36,7 @@ func TestSyncSmallFile2(t *testing.T) {
 	data1 := []byte("json")
 	createTestSmallFile(localPath, len(data), data)
 	createTestSmallFile(remotePath, len(data1), data1)
-	testSyncAnyFile(t, localPath, remotePath)
+	testSyncAnyFile(t, localPath, remotePath, false /* directIO */)
 }
 
 func TestSyncSmallFile3(t *testing.T) {
@@ -49,7 +49,7 @@ func TestSyncSmallFile3(t *testing.T) {
 	data := []byte("json-fault")
 	createTestSmallFile(localPath, len(data), data)
 	createTestSmallFile(remotePath, len(data), data)
-	testSyncAnyFile(t, localPath, remotePath)
+	testSyncAnyFile(t, localPath, remotePath, false /* directIO */)
 }
 
 func TestSyncSmallFile4(t *testing.T) {
@@ -62,7 +62,7 @@ func TestSyncSmallFile4(t *testing.T) {
 	data := []byte("json-fault")
 	createTestSmallFile(localPath, 0, make([]byte, 0))
 	createTestSmallFile(remotePath, len(data), data)
-	testSyncAnyFile(t, localPath, remotePath)
+	testSyncAnyFile(t, localPath, remotePath, false /* directIO */)
 }
 
 func TestSyncAnyFile(t *testing.T) {
@@ -72,14 +72,14 @@ func TestSyncAnyFile(t *testing.T) {
 	// ad hoc test for testing specific problematic files
 	// disabled by default
 	if run {
-		testSyncAnyFile(t, src, dst)
+		testSyncAnyFile(t, src, dst, false /* directIO */)
 	}
 }
 
-func testSyncAnyFile(t *testing.T, src, dst string) {
+func testSyncAnyFile(t *testing.T, src, dst string, directIO bool) {
 	// Sync
 	go rest.TestServer(port, dst, timeout)
-	err := SyncFile(src, localhost+":"+port, timeout)
+	err := SyncFile(src, localhost+":"+port, timeout, directIO)
 
 	// Verify
 	if err != nil {
@@ -542,7 +542,7 @@ func testSyncFile(t *testing.T, layoutLocal, layoutRemote []FileInterval) (hashL
 
 	// Sync
 	go rest.TestServer(port, remotePath, timeout)
-	err := SyncFile(localPath, localhost+":"+port, timeout)
+	err := SyncFile(localPath, localhost+":"+port, timeout, false /* directIO */)
 
 	// Verify
 	if err != nil {
@@ -577,7 +577,7 @@ func Benchmark_1G_InitFiles(b *testing.B) {
 
 func Benchmark_1G_SendFiles_Whole(b *testing.B) {
 	go rest.TestServer(port, remoteBigPath, timeout)
-	err := SyncFile(localBigPath, localhost+":"+port, timeout)
+	err := SyncFile(localBigPath, localhost+":"+port, timeout, false /* directIO */)
 
 	if err != nil {
 		b.Fatal("sync error")
@@ -587,7 +587,7 @@ func Benchmark_1G_SendFiles_Whole(b *testing.B) {
 func Benchmark_1G_SendFiles_Diff(b *testing.B) {
 
 	go rest.TestServer(port, remoteBigPath, timeout)
-	err := SyncFile(localBigPath, localhost+":"+port, timeout)
+	err := SyncFile(localBigPath, localhost+":"+port, timeout, false /* directIO */)
 
 	if err != nil {
 		b.Fatal("sync error")


### PR DESCRIPTION
#### Proposed Changes ####

add command line argument directio to resolve ticket '[BUG] sparse-tools: ssync should explicitly asking for directIO or not, rather than determine is using filesize' (#1943)

1. Add CLI argument `directIO` instead of set directIO using `filesize`
2. Update/Add unit test cases using `directIO`

#### Types of Changes ####

Bug fixing.

#### Verification ####
 
Updated/Added unit test cases

#### Linked Issues ####

Refs: # https://github.com/longhorn/longhorn/issues/1943

#### Further Comments ####

None

Signed-off-by: cclhsu <clark.hsu@suse.com>