### PR TITLE
add logs for debugging snapshot (#2161)

### DIFF
--- a/sparse/client.go
+++ b/sparse/client.go
@@ -38,6 +38,8 @@ func SyncFile(localPath string, remote string, timeout int, directIO bool) error
 	}
 	fileSize := fileInfo.Size()
 	log.Infof("source file size: %d, setting up directIo: %v", fileSize, directIO)
+	startTime := time.Now()
+	log.Infof("Start sending file %s", localPath)
 
 	var fileIo FileIoProcessor
 	if directIO {
@@ -56,6 +58,7 @@ func SyncFile(localPath string, remote string, timeout int, directIO bool) error
 	defer client.closeServer() // kill the server no matter success or not, best effort
 
 	err = client.syncFileContent(fileIo, fileSize)
+	log.Infof("Finish sending file %s and take %v", localPath, time.Since(startTime))
 	if err != nil {
 		log.Errorf("syncFileContent failed: %s", err)
 		return err


### PR DESCRIPTION
#### Proposed Changes ####

add logs for debugging snapshot to resolve ticket '[FEATURE]Add more debug logs for snapshotting' (#2161)

- add sendfile time

#### Types of Changes ####

- enhancement

#### Verification ####

Additional log like following

2021-03-04T04:10:53.970318517Z time="2021-03-04T04:10:53Z" level=info msg="Finish sending file /tmp/test256KB.tmp and take 1.644776033s"

#### Linked Issues ####

Refs: # https://github.com/longhorn/longhorn/issues/2161

#### Further Comments ####

Signed-off-by: Clark Hsu <clark.hsu@suse.com>
```