### PR TITLE
1948 replica rebuild speed up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ debug.test
 #go build binaries
 ssync/ssync
 sfold/sfold
+
+/.idea

--- a/sparse/rest/handlers.go
+++ b/sparse/rest/handlers.go
@@ -162,7 +162,7 @@ func (server *SyncServer) doGetChecksum(writer http.ResponseWriter, request *htt
 	var checksum []byte
 
 	// For the region to have valid data, it can only has one extent covering the whole region
-	exts, err := sparse.GetFiemapRegionExts(server.fileIo, remoteDataInterval)
+	exts, err := sparse.GetFiemapRegionExts(server.fileIo, remoteDataInterval, 2)
 	if len(exts) == 1 && int64(exts[0].Logical) <= remoteDataInterval.Begin &&
 		int64(exts[0].Logical+exts[0].Length) >= remoteDataInterval.End {
 

--- a/sparse/test/fiemap_test.go
+++ b/sparse/test/fiemap_test.go
@@ -1,0 +1,134 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	. "github.com/longhorn/sparse-tools/sparse"
+	"github.com/longhorn/sparse-tools/sparse/rest"
+)
+
+// TestFileSync can be used for benchmarking by default it's skipped
+// for the worst case sparse file, use 4k blocks / 4k holes
+// for a denser sparse file increase the testDataBlockSize
+func TestFileSync(t *testing.T) {
+	const (
+		localhost = "127.0.0.1"
+		timeout   = 10 // seconds
+		port      = "5000"
+
+		MB = int64(1024 * 1024)
+		GB = MB * 1024
+
+		testFileName = srcPrefix + "-fiemap-1gb-file"
+		testFileSize = 1 * GB
+
+		testHoleBlockSize = int64(4096)
+		testDataBlockSize = int64(4096)
+		// testDataBlockSize = int64(128*MB - testHoleBlockSize)
+	)
+
+	t.Skip("skipped fiemap_test::TestFileSyncSparse")
+	log.SetLevel(log.DebugLevel)
+	srcPath := filepath.Join(os.TempDir(), testFileName)
+	if info, err := os.Stat(srcPath); err != nil || info.Size() == 0 {
+		// in case of error we just create a new test file
+		if err = writeMultipleHolesData(srcPath, testFileSize, testDataBlockSize, testHoleBlockSize); err != nil {
+			t.Fatalf("failed to create fiemap test file path: %v error: %v", srcPath, err)
+		}
+	}
+
+	dstPath := filepath.Join(os.TempDir(), testFileName+"-dst")
+
+	// NOTE: depending on scenario you might want to reuse the test files or clean them up
+	// defer fileCleanup(srcPath)
+	// defer fileCleanup(dstPath)
+	log.Info("Syncing file...")
+	startTime := time.Now()
+	go rest.TestServer(context.Background(), port, dstPath, timeout)
+	time.Sleep(time.Second)
+	err := SyncFile(srcPath, localhost+":"+port, timeout, true)
+	if err != nil {
+		t.Fatalf("sync error: %v", err)
+	}
+	log.Infof("Syncing done, size: %v elapsed: %.2fs", testFileSize, time.Now().Sub(startTime).Seconds())
+
+	startTime = time.Now()
+	log.Info("Checking...")
+	err = checkSparseFiles(srcPath, dstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Infof("Checking done, size: %v elapsed: %.2fs", testFileSize, time.Now().Sub(startTime).Seconds())
+}
+
+func writeMultipleHolesData(filePath string, fileSize int64, dataSize int64, holeSize int64) (err error) {
+	if fileSize%(dataSize+holeSize) != 0 {
+		return fmt.Errorf("fileSize %v needs to be a multiple of dataSize %v + holeSize %v", fileSize, dataSize, holeSize)
+	}
+
+	const GB = int64(1024 * 1024 * 1024)
+	sizeInGB := fileSize / GB
+	log.Infof("start to create a %vGB file with multiple hole", sizeInGB)
+	f, err := NewDirectFileIoProcessor(filePath, os.O_RDWR, 0666, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = os.Remove(filePath)
+		}
+	}()
+	defer f.Close()
+	defer f.Sync()
+	if err := f.Truncate(fileSize); err != nil {
+		return err
+	}
+
+	startTime := time.Now()
+	deltaTime := time.Now()
+
+	// random is pretty slow, if called in the loop below for each character
+	// better to call it once per block, so we get a full block of a single random character
+	for offset := int64(0); offset < fileSize; {
+		blockData := RandomBlock(dataSize)
+		if nw, err := f.WriteAt(blockData, offset); err != nil {
+			return fmt.Errorf("write at %v, number of write %v, error: %v", offset, nw, err)
+		}
+		offset += dataSize
+		if err := NewFiemapFile(f.GetFile()).PunchHole(offset, holeSize); err != nil {
+			return fmt.Errorf("punch hole at %v error: %v", offset, err)
+		}
+		offset += holeSize
+
+		if offset%GB == 0 {
+			writtenGB := offset / GB
+			log.Infof("wrote %vGB of %vGB time delta: %.2f time elapsed: %.2f",
+				writtenGB, sizeInGB,
+				time.Now().Sub(deltaTime).Seconds(),
+				time.Now().Sub(startTime).Seconds())
+			deltaTime = time.Now()
+		}
+	}
+
+	log.Infof("done creating a %vGB file with multiple hole, time elapsed: %.2f", sizeInGB, time.Now().Sub(startTime).Seconds())
+	return nil
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandomBlock(n int64) []byte {
+	char := letterBytes[rand.Intn(len(letterBytes))]
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = char
+	}
+	return b
+}

--- a/sparse/test/testutil_test.go
+++ b/sparse/test/testutil_test.go
@@ -206,3 +206,21 @@ func createTestSmallFile(name string, size int, pattern []byte) {
 
 	f.Sync()
 }
+
+func createTestFoldIntervals(fileSize int) (layoutFrom, layoutTo []FileInterval) {
+	blockCount := int64(fileSize) / Blocks
+	for i := int64(0); i < blockCount; i++ {
+		interval := Interval{Begin: i * Blocks, End: (i + 1) * Blocks}
+		layoutFrom = append(layoutFrom, FileInterval{
+			Kind:     FileIntervalKind(1 + (i % 2)),
+			Interval: interval,
+		})
+
+		layoutTo = append(layoutTo, FileInterval{
+			Kind:     FileIntervalKind(1 + ((i + 1) % 2)),
+			Interval: interval,
+		})
+	}
+
+	return layoutFrom, layoutTo
+}

--- a/sparse/util.go
+++ b/sparse/util.go
@@ -1,0 +1,61 @@
+package sparse
+
+import (
+	"context"
+	"sync"
+)
+
+// mergeErrorChannels will merge all error channels into a single error out channel.
+// the error out channel will be closed once the ctx is done or all error channels are closed
+// if there is an error on one of the incoming channels the error will be relayed.
+func mergeErrorChannels(ctx context.Context, channels ...<-chan error) <-chan error {
+	var wg sync.WaitGroup
+	wg.Add(len(channels))
+
+	out := make(chan error, len(channels))
+	output := func(c <-chan error) {
+		defer wg.Done()
+		select {
+		case err, ok := <-c:
+			if ok {
+				out <- err
+			}
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	for _, c := range channels {
+		go output(c)
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+	return out
+}
+
+func processFileIntervals(ctx context.Context, in <-chan FileInterval, processInterval func(interval FileInterval) error) <-chan error {
+	errc := make(chan error, 1)
+	go func() {
+		defer close(errc)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case interval, open := <-in:
+				if !open {
+					return
+				}
+
+				if err := processInterval(interval); err != nil {
+					errc <- err
+					return
+				}
+			}
+		}
+	}()
+	return errc
+}


### PR DESCRIPTION
iterativly retrieve file extents 1024 at a time, these get converted to their relevant fileInterval and pushed out to a buffered channel (10 * 1024) which then gets processed concurrently by 4 worker go routines. 

Below are some test benchmarks for the local unit test, 10x improvement for the worst case 4KB blocks / 4KB holes file
This is the worst case, since in the previous implementation we would have the upfront cost of retrieving & storing all extents as well as pay the http overhead/delay price per extent.

// 120s for 1GB sync on a local server is way to slow
// 12s for 1GB parallel sync segments: 262144/11.32s data: 131072/7.30s holes: 131072/3.90s

For a dense file:
// 1GB file with 1MB data blocks segments: 91857/14.80s data: 90833/14.64s holes: 1024/0.11s
// 1GB file with 4MB data blocks segments: 88827/14.82s data: 88571/14.75s holes: 256/0.01s
// 1GB file with 32MB data blocks segments: 71577/11.92s data: 71545/11.87s holes: 32/0.00s
// 10GB file with 128MB data blocks segments: 716762/132.81s data: 716682/132.40s holes: 80/0.01s
// retrieved extents for file ssync-src-fiemap-10gb-file-dense-128MB, fileSize: 10737418240 elapsed: 130.84s, extents: 716682

extent count is based on the physical structure of the file, a file with the same layout can have different amount of extents
depending on where the filesystem stores the individual blocks, on a defragmented file syncing might reduce to workerCount * io
since we currently parallelize on segments instead of the actual data interval batched (32 * 4096) if this becomes a problem
we can also process the batches for a single data interval concurrently. 

Even if a file is extremely continuous, we would still benefit from the no preprocessing pass as well as  the 4x concurrency factor together with the (32 * 4K) data sends the overhead per send should be lower in comparison to the max sparse case above, we are also able to reuse the prior http connection now.

**Will write up test/benchmark instructions for in cluster testing tomorrow**
**This PR also contains a concurrent fold implementation that is used for snapshot coalescing**

I might also add an additional optimization for checksum calculation, after testing tomorrow.