### PR TITLE
Speed up rebuilding a newly created replica on a node

### DIFF
--- a/cli/ssync/main.go
+++ b/cli/ssync/main.go
@@ -39,7 +39,7 @@ func Main() {
 	if *daemon {
 		if len(args) < 1 {
 			log.Error(usage)
-			log.Fatal("missing file path")
+			log.Fatal("Missing file path")
 		}
 		dstPath := args[0]
 
@@ -51,10 +51,10 @@ func Main() {
 	} else {
 		if len(args) < 1 {
 			log.Error(usage)
-			log.Fatal("missing file path")
+			log.Fatal("Missing file path")
 		}
 		srcPath := args[0]
-		log.Infof("Syncing %s to %s:%s...\n", srcPath, *host, *port)
+		log.Infof("Syncing %s to %s:%s...", srcPath, *host, *port)
 
 		err := sparse.SyncFile(srcPath, *host+":"+*port, *timeout, *directIO, *fastSync)
 		if err != nil {

--- a/sparse/file.go
+++ b/sparse/file.go
@@ -190,11 +190,10 @@ func ReadDataInterval(rw ReaderWriterAt, dataInterval Interval) ([]byte, error) 
 	n, err := rw.ReadAt(data, dataInterval.Begin)
 	if err != nil {
 		if err == io.EOF {
-			log.Debugf("have read at the end of file, total read: %d", n)
+			log.Debugf("Have read at the end of file, total read: %d", n)
 		} else {
-			err = errors.Wrapf(err, "failed to read interval %+v", dataInterval)
-			log.Error(err)
-			return nil, err
+			log.WithError(err).Errorf("Failed to read interval %+v", dataInterval)
+			return nil, errors.Wrapf(err, "failed to read interval %+v", dataInterval)
 		}
 	}
 	return data[:n], nil
@@ -345,7 +344,7 @@ func GetFiemapRegionExts(file FileIoProcessor, interval Interval, extCount int) 
 	retrievalStart := time.Now()
 	_, exts, errno := file.GetFieMap().FiemapRegion(uint32(extCount), uint64(interval.Begin), uint64(interval.End-interval.Begin))
 	if errno != 0 {
-		log.Error("failed to call fiemap.Fiemap(extCount)")
+		log.Error("Failed to call fiemap.Fiemap(extCount)")
 		return exts, fmt.Errorf(errno.Error())
 	}
 

--- a/sparse/rest/server.go
+++ b/sparse/rest/server.go
@@ -3,7 +3,9 @@ package rest
 import (
 	"context"
 	"net/http"
+	"os"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/longhorn/sparse-tools/sparse"
@@ -25,6 +27,8 @@ type SyncServer struct {
 	ctx         context.Context
 	cancelFunc  context.CancelFunc
 
+	fileAlreadyExists bool
+
 	srv *http.Server
 }
 
@@ -34,12 +38,20 @@ func Server(ctx context.Context, port string, filePath string, syncFileOps SyncF
 	srv := &http.Server{
 		Addr: ":" + port,
 	}
+
+	fileAlreadyExists := true
+	if _, err := os.Stat(filePath); err != nil && errors.Is(err, os.ErrNotExist) {
+		log.Infof("file %v does not exist", filePath)
+		fileAlreadyExists = false
+	}
+
 	syncServer := &SyncServer{
-		filePath:    filePath,
-		syncFileOps: syncFileOps,
-		ctx:         ctx,
-		cancelFunc:  cancelFunc,
-		srv:         srv,
+		filePath:          filePath,
+		syncFileOps:       syncFileOps,
+		ctx:               ctx,
+		cancelFunc:        cancelFunc,
+		srv:               srv,
+		fileAlreadyExists: fileAlreadyExists,
 	}
 	srv.Handler = NewRouter(syncServer)
 

--- a/sparse/test/fiemap_test.go
+++ b/sparse/test/fiemap_test.go
@@ -77,7 +77,7 @@ func writeMultipleHolesData(filePath string, fileSize int64, dataSize int64, hol
 
 	const GB = int64(1024 * 1024 * 1024)
 	sizeInGB := fileSize / GB
-	log.Infof("start to create a %vGB file with multiple hole", sizeInGB)
+	log.Infof("Start to create a %vGB file with multiple hole", sizeInGB)
 	f, err := NewDirectFileIoProcessor(filePath, os.O_RDWR, 0666, true)
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ func writeMultipleHolesData(filePath string, fileSize int64, dataSize int64, hol
 
 		if offset%GB == 0 {
 			writtenGB := offset / GB
-			log.Infof("wrote %vGB of %vGB time delta: %.2f time elapsed: %.2f",
+			log.Infof("Wrote %vGB of %vGB time delta: %.2f time elapsed: %.2f",
 				writtenGB, sizeInGB,
 				time.Now().Sub(deltaTime).Seconds(),
 				time.Now().Sub(startTime).Seconds())
@@ -119,7 +119,7 @@ func writeMultipleHolesData(filePath string, fileSize int64, dataSize int64, hol
 		}
 	}
 
-	log.Infof("done creating a %vGB file with multiple hole, time elapsed: %.2f", sizeInGB, time.Now().Sub(startTime).Seconds())
+	log.Infof("Done creating a %vGB file with multiple hole, time elapsed: %.2f", sizeInGB, time.Now().Sub(startTime).Seconds())
 	return nil
 }
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -42,11 +42,11 @@ func verifySampleDurations(m []model) bool {
 	for _, expected := range m {
 		sample := <-samples
 		if !expected.durationIgnore && sample.duration != time.Duration(expected.duration) {
-			log.Error("queue duration mismatch; expected=", sample.duration, "actual=", time.Duration(expected.duration))
+			log.Error("Queue duration mismatch; expected=", sample.duration, "actual=", time.Duration(expected.duration))
 			return false
 		}
 		if sample.size != expected.size {
-			log.Error("queue size mismatch; expected=", sample.size, "actual=", expected.size)
+			log.Error("Queue size mismatch; expected=", sample.size, "actual=", expected.size)
 			return false
 		}
 	}


### PR DESCRIPTION
Speed up rebuilding a newly created replica on a node rather than using a failed replica.
1. Avoid unnecessary local data checksum calculation
2. Increase the chunk size to 2 MiB

Longhorn/longhorn#4092

Signed-off-by: Derek Su <derek.su@suse.com>