### PR TITLE
Revert "sync file: buffering read disk files for replica rebuild"

### DIFF
--- a/sparse/client.go
+++ b/sparse/client.go
@@ -110,7 +110,7 @@ func SyncFile(localPath string, remote string, httpClientTimeout int, directIO, 
 
 	log.Infof("Syncing file %v to %v: size %v, directIO %v, fastSync %v", localPath, remote, fileSize, directIO, fastSync)
 
-	fileIo, err := NewBufferedFileIoProcessor(localPath, os.O_RDONLY, 0)
+	fileIo, err := newFileIoProcessor(localPath, directIO)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to open local source file %v", localPath)
 		return err
@@ -118,6 +118,13 @@ func SyncFile(localPath string, remote string, httpClientTimeout int, directIO, 
 	defer fileIo.Close()
 
 	return SyncContent(fileIo.Name(), fileIo, fileSize, remote, httpClientTimeout, directIO, fastSync)
+}
+
+func newFileIoProcessor(localPath string, directIO bool) (FileIoProcessor, error) {
+	if directIO {
+		return NewDirectFileIoProcessor(localPath, os.O_RDONLY, 0)
+	}
+	return NewBufferedFileIoProcessor(localPath, os.O_RDONLY, 0)
 }
 
 func SyncContent(sourceName string, rw ReaderWriterAt, fileSize int64, remote string, httpClientTimeout int, directIO, fastSync bool) (err error) {


### PR DESCRIPTION
This reverts commit 727da1d6548d7d79a9095710cc56c77194ad3b08.

The instance-manager-r's memory usage increases due to the cache memory. 
After the rebuilding, the memory usage of the instance-manager-r increases. This is not harmful. However, to avoid uncertainties caused by the checks of pods' memory usages, we revert the commit.
    
Longhorn/longhorn#5130