### PR TITLE
feat: shutdown sparse rest server after being idle for a period of time

### DIFF
--- a/sparse/rest/server.go
+++ b/sparse/rest/server.go
@@ -2,14 +2,57 @@ package rest
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/longhorn/sparse-tools/sparse"
 )
+
+var (
+	defaultIdleTimeout     = 90 * time.Second
+	defaultHTTPIdleTimeout = 60 * time.Second
+)
+
+type IdleTimer struct {
+	sync.Mutex
+	activeConns map[net.Conn]bool
+	timeout     time.Duration
+	timer       *time.Timer
+}
+
+func NewIdleTimer(idleTimeout time.Duration) *IdleTimer {
+	return &IdleTimer{
+		activeConns: make(map[net.Conn]bool),
+		timeout:     idleTimeout,
+		timer:       time.NewTimer(idleTimeout),
+	}
+}
+
+func (it *IdleTimer) ConnState(conn net.Conn, state http.ConnState) {
+	it.Lock()
+	defer it.Unlock()
+
+	switch state {
+	case http.StateNew, http.StateActive, http.StateHijacked:
+		it.activeConns[conn] = true
+		it.timer.Stop()
+	case http.StateIdle, http.StateClosed:
+		delete(it.activeConns, conn)
+		if len(it.activeConns) == 0 {
+			it.timer.Reset(it.timeout)
+		}
+	}
+}
+
+func (t *IdleTimer) Done() <-chan time.Time {
+	return t.timer.C
+}
 
 type DataSyncServer interface {
 	open(writer http.ResponseWriter, request *http.Request)
@@ -36,8 +79,13 @@ func Server(ctx context.Context, port string, filePath string, syncFileOps SyncF
 	log.Infof("Creating Ssync service")
 	ctx, cancelFunc := context.WithCancel(ctx)
 	srv := &http.Server{
-		Addr: ":" + port,
+		Addr:        ":" + port,
+		IdleTimeout: defaultHTTPIdleTimeout,
 	}
+
+	// if server has no connection for a period of time, it will shutdown itself to prevent receiver from getting stuck.
+	idleTimer := NewIdleTimer(defaultIdleTimeout)
+	srv.ConnState = idleTimer.ConnState
 
 	fileAlreadyExists := true
 	if _, err := os.Stat(filePath); err != nil && errors.Is(err, os.ErrNotExist) {
@@ -56,8 +104,13 @@ func Server(ctx context.Context, port string, filePath string, syncFileOps SyncF
 	srv.Handler = NewRouter(syncServer)
 
 	go func() {
-		<-ctx.Done()
-		srv.Close()
+		select {
+		case <-ctx.Done():
+			srv.Close()
+		case <-idleTimer.Done():
+			log.Errorf("Shutting down the server since it is idle for %v", idleTimer.timeout)
+			srv.Close()
+		}
 	}()
 
 	return srv.ListenAndServe()


### PR DESCRIPTION
ref: [longhorn/longhorn#4305](https://github.com/longhorn/longhorn/issues/4305)

<img width="707" alt="224952059-68c092bd-b3bd-4ef9-aced-12dd87f05574" src="https://user-images.githubusercontent.com/7100904/225269880-20bf7e67-67a6-4e66-800a-97862c2e25c6.png">

Most of our sync file scenerios are like above process.
The one receiving the file will launch the server and wait for sender as client to send the file.
After sending the file, sender will POST `close()` to the server to close it.

However, there is a chance that if the sender crashes, the receiver will get stuck since no one will help it to shut down the server.
In BackingImage sync case, this will make the BackingImage stuck in `in-progress` status forever.

Hence, we add an idle timeout to the server to allow it shutdowns itself when there is no conn for a period of time.