### PR TITLE
chore: the io/ioutil package is deprecated from Go 1.16

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,7 +19,7 @@ RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.13.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.17.10.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && GO111MODULE=on go get golang.org/x/lint/golint@v0.0.0-20210508222113-6edffad5e616
 
 ENV DAPPER_SOURCE /go/src/github.com/longhorn/sparse-tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/longhorn/sparse-tools
 
-go 1.13
+go 1.17
 
 require (
 	github.com/google/uuid v1.3.0

--- a/sparse/client.go
+++ b/sparse/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -255,7 +254,7 @@ func getLocalDiskFileChangeTimeAndChecksum(sourceName string) (recordedChangeTim
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "failed to read checksum file")
 	}
@@ -341,7 +340,7 @@ func (client *syncClient) open() error {
 	}
 
 	// drain the buffer and close the body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -363,7 +362,7 @@ func (client *syncClient) close() {
 	resp, err := client.sendHTTPRequest("POST", "close", queries, nil)
 	if err == nil {
 		// drain the buffer and close the body
-		_, _ = ioutil.ReadAll(resp.Body)
+		_, _ = io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 	}
 }
@@ -378,7 +377,7 @@ func (client *syncClient) syncHoleInterval(holeInterval Interval) error {
 	}
 
 	// drain the buffer and close the body
-	_, _ = ioutil.ReadAll(resp.Body)
+	_, _ = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -399,7 +398,7 @@ func (client *syncClient) getServerChecksum(batchInterval Interval) ([]byte, err
 	}
 
 	// drain the buffer and close the body
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -427,7 +426,7 @@ func (client *syncClient) getServerRecordedMetadata() ([]byte, error) {
 	}
 
 	// drain the buffer and close the body
-	metadata, err := ioutil.ReadAll(resp.Body)
+	metadata, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
@@ -448,7 +447,7 @@ func (client *syncClient) writeData(dataInterval Interval, data []byte) error {
 	}
 
 	// drain the buffer and close the body
-	_, _ = ioutil.ReadAll(resp.Body)
+	_, _ = io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {

--- a/sparse/rest/handlers.go
+++ b/sparse/rest/handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -248,7 +247,7 @@ func (server *SyncServer) doWriteData(request *http.Request) error {
 
 	log.Tracef("writeData: interval %+v", remoteDataInterval)
 
-	data, err := ioutil.ReadAll(io.LimitReader(request.Body, remoteDataInterval.End-remoteDataInterval.Begin))
+	data, err := io.ReadAll(io.LimitReader(request.Body, remoteDataInterval.End-remoteDataInterval.Begin))
 	if err != nil {
 		return errors.Wrap(err, "failed to read request")
 	}
@@ -313,7 +312,7 @@ func (server *SyncServer) getRecordedMetadataFromChecksumFile() ([]byte, error) 
 	}
 	defer f.Close()
 
-	metadata, err := ioutil.ReadAll(f)
+	metadata, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read checksum file")
 	}

--- a/sparse/test/directfio_test.go
+++ b/sparse/test/directfio_test.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"os"
 	"testing"
-
 	"time"
-
-	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
 
@@ -16,7 +13,7 @@ import (
 
 func tempFilePathDirectIo() string {
 	// Make a temporary file path
-	f, err := ioutil.TempFile("", "directIO-test")
+	f, err := os.CreateTemp("", "directIO-test")
 	if err != nil {
 		log.Fatal("Failed to make temp file", err)
 	}
@@ -28,7 +25,7 @@ func tempFilePathDirectIo() string {
 // created in current directory
 func tempBigFilePathDirectIo() string {
 	// Make a temporary file path in current dir
-	f, err := ioutil.TempFile(".", "directIO-test")
+	f, err := os.CreateTemp(".", "directIO-test")
 	if err != nil {
 		log.Fatal("Failed to make temp file", err)
 	}

--- a/sparse/test/testutil_test.go
+++ b/sparse/test/testutil_test.go
@@ -1,13 +1,11 @@
 package test
 
 import (
-	"io/ioutil"
+	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
 	"time"
-
-	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -41,7 +39,7 @@ func fileCleanup(path string) {
 
 func tempFilePath(prefix string) string {
 	// Make a temporary file path
-	f, err := ioutil.TempFile("", "sparse-"+prefix)
+	f, err := os.CreateTemp("", "sparse-"+prefix)
 	if err != nil {
 		log.Fatal("Failed to make temp file", err)
 	}
@@ -53,7 +51,7 @@ func tempFilePath(prefix string) string {
 // created in current directory
 func tempBigFilePath(prefix string) string {
 	// Make a temporary file path in current dir
-	f, err := ioutil.TempFile(".", "sparse-"+prefix)
+	f, err := os.CreateTemp(".", "sparse-"+prefix)
 	if err != nil {
 		log.Fatal("Failed to make temp file", err)
 	}

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1,7 +1,7 @@
 package stats
 
 import (
-	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -11,7 +11,7 @@ import (
 
 func tempFilePath() string {
 	// Make a temporary file path
-	f, err := ioutil.TempFile("", "stat-test")
+	f, err := os.CreateTemp("", "stat-test")
 	if err != nil {
 		log.Fatal("Failed to make temp file", err)
 	}


### PR DESCRIPTION
### Propose Changes
- The `io/ioutil` package is deprecated.
- Update the base Go version from 1.13 to 1.17.