### PR TITLE
fix: return the whole data buf

### DIFF
--- a/sparse/file.go
+++ b/sparse/file.go
@@ -196,7 +196,7 @@ func ReadDataInterval(rw ReaderWriterAt, dataInterval Interval) ([]byte, error) 
 			return nil, errors.Wrapf(err, "failed to read interval %+v", dataInterval)
 		}
 	}
-	return data[:n], nil
+	return data, nil
 }
 
 func WriteDataInterval(file FileIoProcessor, dataInterval Interval, data []byte) error {


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/6899

#### What this PR does / why we need it:
When sending the batch with the interval, we allocate the `buf` with the batch size (interval size) and read data from the volume into it.
Then we send the `buf` as the data with the interval information to the target volume to write the data in that interval
We should not cut the data with the count we actually read from volume because that would be incorrect in the below example
```
Assuming we have a Volume and a snapshot chain
0 nil
1 BackingImage [0:2MB]
2 Snapshot1 [0:16MB]
 
We write some data to the Volume [3MB:4MB]

When we are exporting the Volume with block size 2MB, 
the preload index map will indicate that for [2MB:4MB] data
[2MB:3MB] should be read BackingImage
[3MB:4MB] should be read from snap1

Then since [2MB:3MB] is out of the bound of BackingImage,
we can't read the volume and the read count will be 0
[3MB:4MB] has the data and the read count would be 1MB

So the `buf` we read from the volume will be [0,0,0,.....0, x, x,x, ..., x]
If we cut the return data with the count, then we only get 1MB of [0,0,0,...,0] 
```

#### Special notes for your reviewer:
This function is a util function used in all sync content related feature.
I think if we test volume clone feature with volume expansion we might encounter the same issue.

#### Additional documentation or context

cc @shuo-wu @PhanLe1010 