### PR TITLE
reset err before return nil

### DIFF
--- a/sparse/client.go
+++ b/sparse/client.go
@@ -157,6 +157,7 @@ func SyncContent(sourceName string, rw ReaderWriterAt, fileSize int64, remote st
 	if fastSync && filepath.Ext(client.sourceName) == types.SnapshotDiskSuffix {
 		if client.isLocalAndRemoteDiskFilesIdentical() {
 			log.Infof("Skipped syncing file %v", client.sourceName)
+			err = nil // the err could be set via getLocalDiskFileChangeTimeAndChecksum() and would be return via defer()
 			return nil
 		}
 	}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

by reviewing the transfer code for https://github.com/longhorn/longhorn/issues/8745
i have found, that the `return nil` is ineffective when the err was set before via `getLocalDiskFileChangeTimeAndChecksum()`, the defer func wraps the existing filled `err` variable and returns an error even it wants to return nil. 

